### PR TITLE
fix bug of digit dir name navigate

### DIFF
--- a/omxfront/interface.htm
+++ b/omxfront/interface.htm
@@ -57,7 +57,7 @@
 		
 		function navigate(relativePath) {
 			$('#navigation').data('relative', relativePath);
-			$('#navigationback').data('relative', $('#navigation').data('relative').replace(/\/?[^/]+$/, ''));
+			$('#navigationback').data('relative', $('#navigation').data('relative').toString().replace(/\/?[^/]+$/, ''));
 			//alert($('#navigationback').data('relative'));
 			$('#navigationback').attr('href', navigationBase + $('#navigationback').data('relative'));
 			


### PR DESCRIPTION
when a dir name is digit, navigate function not work, because result of "data('relative')" is a number, without "replace" method.